### PR TITLE
Update default button color

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-white text-white shadow-xs hover:bg-primary/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:


### PR DESCRIPTION
## Summary
- set default button variant background and text color to white

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843210124088331bba0afdd9a1c33ca
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed the default button color to white for both background and text.

<!-- End of auto-generated description by cubic. -->

