### PR TITLE
Implement profile fetch after login

### DIFF
--- a/pages/api/user-profile.ts
+++ b/pages/api/user-profile.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { user_id } = req.query;
+  if (!user_id || Array.isArray(user_id)) {
+    return res.status(400).json({ error: 'Missing user_id' });
+  }
+
+  const directusUrl = process.env.API_URL;
+  if (!directusUrl) {
+    return res.status(500).json({ error: 'Missing API_URL' });
+  }
+
+  try {
+    const response = await fetch(`${directusUrl}/items/users/${user_id}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch profile: ${response.status}`);
+    }
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error: any) {
+    console.error('Profile API error:', error);
+    return res.status(500).json({ error: 'Failed to fetch profile', message: error.message });
+  }
+}
+
+export const config = { api: { bodyParser: false } };


### PR DESCRIPTION
## Summary
- add API route `/api/user-profile` to fetch individual user data from Directus
- load profile data in dashboard after successful login and show phone number in the account dropdown

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68432f2d0650833181406ee387bf4bf5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new API route to fetch user profile data after login and display the user's phone number in the dashboard account dropdown.

- **New Features**
  - Created `/api/user-profile` to get user data from Directus.
  - Dashboard now loads and shows the user's phone number after login.

<!-- End of auto-generated description by cubic. -->

