### PR TITLE
Centralize API endpoints

### DIFF
--- a/api/file.ts
+++ b/api/file.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -90,7 +90,7 @@ interface MenuItemConfig {
 }
 
 // ===== CONSTANTS =====
-const API_BASE_URL = "http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055";
+import { API_BASE_URL } from '../api/file';
 const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const ONLINE_THRESHOLD_MINUTES = 30;
 const ALERT_THRESHOLDS = {

--- a/components/CommandCenter.tsx
+++ b/components/CommandCenter.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { API_BASE_URL } from "../api/file";
 import { toast } from "sonner";
 import { 
   Command as CommandIcon, 
@@ -171,7 +172,7 @@ export function CommandCenter() {
     setVehicleError(null);
     
     try {
-      const response = await fetch("http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle");
+      const response = await fetch(`${API_BASE_URL}/items/vehicle`);
       
       console.log('📡 Vehicle fetch response:', response.status, response.statusText);
       
@@ -253,7 +254,7 @@ export function CommandCenter() {
   const fetchCommandHistory = async () => {
     try {
       console.log('📜 Fetching command history...');
-      const response = await fetch("http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/commands?sort=-date_created");
+      const response = await fetch(`${API_BASE_URL}/items/commands?sort=-date_created`);
       
       if (!response.ok) {
         console.warn('⚠️ Failed to fetch command history, using sample data');
@@ -473,7 +474,7 @@ export function CommandCenter() {
       console.log('📤 Recording command in history:', commandData);
       
       // Send command to command history API
-      const historyResponse = await fetch('http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/commands', {
+      const historyResponse = await fetch(`${API_BASE_URL}/items/commands`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -496,7 +497,7 @@ export function CommandCenter() {
       console.log(`📤 Updating vehicle ${selectedVehicle} relay status to ${newRelayStatus}`);
       
       // Update the vehicle record with the new relay status
-      const vehicleUpdateResponse = await fetch(`http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle/${selectedVehicle}`, {
+      const vehicleUpdateResponse = await fetch(`${API_BASE_URL}/items/vehicle/${selectedVehicle}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -517,7 +518,7 @@ export function CommandCenter() {
       const historyResult = await historyResponse.json();
       if (historyResult && historyResult.data && historyResult.data.id) {
         const commandId = historyResult.data.id;
-        const updateResponse = await fetch(`http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/commands/${commandId}`, {
+        const updateResponse = await fetch(`${API_BASE_URL}/items/commands/${commandId}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -108,7 +108,7 @@ interface DashboardStats {
 }
 
 // ===== CONSTANTS =====
-const API_BASE_URL = "http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055";
+import { API_BASE_URL } from '../api/file';
 
 const REFRESH_INTERVALS = {
   VEHICLES: 30000,      // 30 seconds

--- a/components/GeofenceManager.tsx
+++ b/components/GeofenceManager.tsx
@@ -85,7 +85,7 @@ interface UIState {
 }
 
 // 🔧 Constants with environment support
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';
+import { API_BASE_URL } from '../api/file';
 const GEOFENCE_API_ENDPOINT = `${API_BASE_URL}/items/geofence`;
 const VEHICLE_API_ENDPOINT = `${API_BASE_URL}/items/vehicle`;
 

--- a/components/HistoryManager.tsx
+++ b/components/HistoryManager.tsx
@@ -60,9 +60,9 @@ interface ProcessedVehicleForMap {
 }
 
 // API Configuration
-const API_BASE_URL = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items';
-const VEHICLE_ENDPOINT = `${API_BASE_URL}/vehicle`;
-const VEHICLE_DATA_ENDPOINT = `${API_BASE_URL}/vehicle_datas`;
+import { API_BASE_URL } from '../api/file';
+const VEHICLE_ENDPOINT = `${API_BASE_URL}/items/vehicle`;
+const VEHICLE_DATA_ENDPOINT = `${API_BASE_URL}/items/vehicle_datas`;
 
 // 🔧 Optimized SWR Configuration
 const swrConfig = {

--- a/components/LiveTracking.tsx
+++ b/components/LiveTracking.tsx
@@ -26,6 +26,7 @@ import {
 import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
 import useSWR from 'swr';
+import { API_BASE_URL } from '../api/file';
 
 const MapComponent = dynamic(() => import('./MapComponent').catch(() => ({ default: () => <div>Map not available</div> })), {
   ssr: false,
@@ -129,7 +130,6 @@ interface VehiclePositionHistory {
 }
 
 // API Configuration
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';
 const GEOFENCE_API_BASE_URL = `${API_BASE_URL}/items/geofence`;
 const VEHICLE_API_ENDPOINT_BASE = `${API_BASE_URL}/items/vehicle`;
 const VEHICLE_DATA_API_ENDPOINT_BASE = `${API_BASE_URL}/items/vehicle_datas`;

--- a/lib/alertService.ts
+++ b/lib/alertService.ts
@@ -8,7 +8,9 @@ export interface Alert {
   timestamp: string;
 }
 
-const ALERTS_API_URL = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/alerts';
+import { API_BASE_URL } from '../api/file';
+
+const ALERTS_API_URL = `${API_BASE_URL}/items/alerts`;
 
 export const saveAlert = async (alert: Alert) => {
   try {

--- a/lib/geofenceDetector.ts
+++ b/lib/geofenceDetector.ts
@@ -258,7 +258,9 @@ export class GeofenceDetector {
 }
 
 // --- Fungsi untuk menyimpan event ke API ---
-const GEOFENCE_EVENTS_API_ENDPOINT = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/geofence_events';
+import { API_BASE_URL } from '../api/file';
+
+const GEOFENCE_EVENTS_API_ENDPOINT = `${API_BASE_URL}/items/geofence_events`;
 
 export async function saveGeofenceEventToApi(event: GeofenceEvent): Promise<boolean> {
   const payload: ApiGeofenceEventPayload = {

--- a/pages/api/alerts.ts
+++ b/pages/api/alerts.ts
@@ -52,8 +52,8 @@ export default async function handler(
     console.log(`📊 Fetching alerts with limit: ${alertLimit}`);
 
     // Fetch data dari Directus API
-    const directusUrl = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';
-    const response = await fetch(`${directusUrl}/items/alerts?limit=-1&sort=-alert_id`, {
+    const { API_BASE_URL } = await import('../../api/file');
+    const response = await fetch(`${API_BASE_URL}/items/alerts?limit=-1&sort=-alert_id`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/pages/api/auth/verify-otp.ts
+++ b/pages/api/auth/verify-otp.ts
@@ -58,7 +58,8 @@ export default async function handler(
     
     // Fetch user data
     console.log('Fetching user data...');
-    const response = await fetch('http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/users');
+    const { API_BASE_URL } = await import('../../../api/file');
+    const response = await fetch(`${API_BASE_URL}/items/users`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch users');

--- a/pages/api/users/route.ts
+++ b/pages/api/users/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from 'next/server';
 
 export async function GET() {
   try {
-    const response = await fetch('http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/users');
+    const { API_BASE_URL } = await import('../../../api/file');
+    const response = await fetch(`${API_BASE_URL}/items/users`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch users');

--- a/pages/api/vehicle-data.ts
+++ b/pages/api/vehicle-data.ts
@@ -22,7 +22,8 @@ export default async function handler(
 
     // 1. First, get the user's vehicles to get their gps_ids
     console.log('Getting vehicles for user:', user_id);
-    const vehiclesUrl = `http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle?filter[user_id][_eq]=${user_id}`;
+    const { API_BASE_URL } = await import('../../api/file');
+    const vehiclesUrl = `${API_BASE_URL}/items/vehicle?filter[user_id][_eq]=${user_id}`;
     
     const vehiclesResponse = await fetch(vehiclesUrl, {
       method: 'GET',
@@ -61,7 +62,7 @@ export default async function handler(
     }
     
     // 3. Fetch all vehicle_datas with the exact endpoint specified
-    const vehicleDataUrl = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle_datas?limit=-1';
+    const vehicleDataUrl = `${API_BASE_URL}/items/vehicle_datas?limit=-1`;
     
     const response = await fetch(vehicleDataUrl, {
       method: 'GET',

--- a/pages/api/vehicles.ts
+++ b/pages/api/vehicles.ts
@@ -22,7 +22,8 @@ async function handleGetVehicles(req: NextApiRequest, res: NextApiResponse) {
     const { user_id } = req.query;
     console.log('Fetching vehicles data for user_id:', user_id);
     
-    let url = 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle';
+    const { API_BASE_URL } = await import('../../api/file');
+    let url = `${API_BASE_URL}/items/vehicle`;
     
     // Add filter if user_id is provided
     if (user_id) {
@@ -78,8 +79,9 @@ async function handleCreateVehicle(req: NextApiRequest, res: NextApiResponse) {
     }
     
     // Create vehicle via external API
+    const { API_BASE_URL } = await import('../../api/file');
     const response = await fetch(
-      'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle',
+      `${API_BASE_URL}/items/vehicle`,
       {
         method: 'POST',
         headers: {

--- a/pages/api/vehicles/[id].ts
+++ b/pages/api/vehicles/[id].ts
@@ -1,5 +1,6 @@
 // pages/api/vehicles/[id].ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { API_BASE_URL } from '../../../api/file';
 
 export default async function handler(
   req: NextApiRequest,
@@ -33,7 +34,7 @@ async function handleDeleteVehicle(req: NextApiRequest, res: NextApiResponse) {
     
     // Delete vehicle via external API
     const response = await fetch(
-      `http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle/${id}`,
+      `${API_BASE_URL}/items/vehicle/${id}`,
       {
         method: 'DELETE',
         headers: {
@@ -100,7 +101,7 @@ async function handleGetVehicle(req: NextApiRequest, res: NextApiResponse) {
     }
     
     const response = await fetch(
-      `http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle/${id}`,
+      `${API_BASE_URL}/items/vehicle/${id}`,
       {
         method: 'GET',
         headers: {
@@ -143,7 +144,7 @@ async function handleUpdateVehicle(req: NextApiRequest, res: NextApiResponse) {
     
     // Update vehicle via external API
     const response = await fetch(
-      `http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055/items/vehicle/${id}`,
+      `${API_BASE_URL}/items/vehicle/${id}`,
       {
         method: 'PATCH',
         headers: {


### PR DESCRIPTION
## Summary
- centralize HTTP base URL in `api/file.ts`
- replace hardcoded URLs with `API_BASE_URL`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68434e55f7f88331a44d4137b6c3def1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Centralized the API base URL in a single file and updated all code to use this shared constant instead of hardcoded URLs.

- **Refactors**
  - Added `api/file.ts` to export `API_BASE_URL`.
  - Replaced all direct API URLs with `API_BASE_URL` imports across components and API routes.

<!-- End of auto-generated description by cubic. -->

