### PR TITLE
Fix sidebar cache null check

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -265,7 +265,7 @@ const useVehicleData = (userId: string | null) => {
     const cacheAge = cacheRef.current ? now - cacheRef.current.timestamp : Infinity;
     const shouldUseCache = !forceRefresh && cacheRef.current && cacheAge < 60000; // 1 minute cache
 
-    if (shouldUseCache) {
+    if (shouldUseCache && cacheRef.current) {
       const { vehicles, statusData } = cacheRef.current;
       
       const onlineCount = vehicles.filter(vehicle => 


### PR DESCRIPTION
## Summary
- avoid using cached data when it might be null

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843511db77c8331b658fec16c05311d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug in the sidebar cache logic to prevent using null cached data.

<!-- End of auto-generated description by cubic. -->

