### PR TITLE
Fix Next.js config file for Vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,4 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
+const nextConfig = {
   reactStrictMode: true,
 
   // Lewati pengecekan ESLint saat build
@@ -15,7 +13,7 @@ const nextConfig: NextConfig = {
     "react-leaflet-draw",
   ],
 
-  webpack: (config: any, { isServer }: { isServer: boolean }) => {
+  webpack: (config, { isServer }) => {
     // Hanya jalankan jika tidak pakai Turbopack
     if (!process.env.__NEXT_EXPERIMENTAL_TURBOPACK) {
       config.resolve = config.resolve || {};


### PR DESCRIPTION
## Summary
- rename `next.config.ts` to `next.config.mjs`
- remove TypeScript syntax so Next.js can load the config without a TS compiler

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68435498dc408331abf455954fb68525
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the Next.js config file to next.config.mjs and removed TypeScript syntax so Vercel can load the config without errors.

<!-- End of auto-generated description by cubic. -->

