### PR TITLE
Fix sidebar cache null check

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -265,7 +265,7 @@ const useVehicleData = (userId: string | null) => {
     const cacheAge = cacheRef.current ? now - cacheRef.current.timestamp : Infinity;
     const shouldUseCache = !forceRefresh && cacheRef.current && cacheAge < 60000; // 1 minute cache
 
-    if (shouldUseCache) {
+    if (shouldUseCache && cacheRef.current) {
       const { vehicles, statusData } = cacheRef.current;
       
       const onlineCount = vehicles.filter(vehicle => 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -31,6 +31,9 @@ const MapComponent = dynamic(() => import('./MapComponent'), {
   )
 });
 
+// Reuse MapComponent vehicle type for consistency
+import type { ProcessedVehicle as MapVehicle } from './MapComponent';
+
 // ===== INTERFACES & TYPES =====
 interface Vehicle {
   vehicle_id: string;
@@ -63,21 +66,7 @@ interface VehicleData {
   satellites_used: number | null;
 }
 
-interface ProcessedVehicle {
-  id: string;
-  name: string;
-  licensePlate: string;
-  position: [number, number];
-  speed: number;
-  ignition: boolean;
-  fuel: number | null;
-  battery: number | null;
-  timestamp: string | null;
-  isMotor: boolean;
-  make?: string;
-  model?: string;
-  year?: number;
-  status: 'moving' | 'parked' | 'offline';
+interface ProcessedVehicle extends MapVehicle {
   isOnline: boolean;
   location: string;
   latestData?: VehicleData;
@@ -496,7 +485,7 @@ export function Dashboard() {
   }, [processedVehicles]);
 
   // Event handlers
-  const handleVehicleClick = useCallback((vehicle: ProcessedVehicle) => {
+  const handleVehicleClick = useCallback((vehicle: MapVehicle) => {
     console.log('Dashboard: Vehicle selected from map:', vehicle.name);
     setSelectedVehicleId(vehicle.id);
   }, []);

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -29,7 +29,7 @@ interface ProjectGeofence {
 }
 
 // Simplified interfaces for map display
-interface ProcessedVehicle {
+export interface ProcessedVehicle {
   id: string;
   name: string;
   licensePlate: string;


### PR DESCRIPTION
## Summary
- avoid using cached data when it might be null
- reuse MapComponent's vehicle type in Dashboard
- fix type mismatch for map vehicle click handler

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843511db77c8331b658fec16c05311d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a sidebar caching bug that could use null data, and updated Dashboard to reuse the MapComponent vehicle type for consistency.

- **Bug Fixes**
  - Added a null check to prevent using invalid cached data in the sidebar.
  - Fixed a type mismatch in the Dashboard map vehicle click handler.

<!-- End of auto-generated description by cubic. -->

