### PR TITLE
Fix sidebar cache null check

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -265,7 +265,7 @@ const useVehicleData = (userId: string | null) => {
     const cacheAge = cacheRef.current ? now - cacheRef.current.timestamp : Infinity;
     const shouldUseCache = !forceRefresh && cacheRef.current && cacheAge < 60000; // 1 minute cache
 
-    if (shouldUseCache) {
+    if (shouldUseCache && cacheRef.current) {
       const { vehicles, statusData } = cacheRef.current;
       
       const onlineCount = vehicles.filter(vehicle => 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -31,6 +31,9 @@ const MapComponent = dynamic(() => import('./MapComponent'), {
   )
 });
 
+// Reuse MapComponent vehicle type for consistency
+import type { ProcessedVehicle as MapVehicle } from './MapComponent';
+
 // ===== INTERFACES & TYPES =====
 interface Vehicle {
   vehicle_id: string;
@@ -63,21 +66,7 @@ interface VehicleData {
   satellites_used: number | null;
 }
 
-interface ProcessedVehicle {
-  id: string;
-  name: string;
-  licensePlate: string;
-  position: [number, number];
-  speed: number;
-  ignition: boolean;
-  fuel: number | null;
-  battery: number | null;
-  timestamp: string | null;
-  isMotor: boolean;
-  make?: string;
-  model?: string;
-  year?: number;
-  status: 'moving' | 'parked' | 'offline';
+interface ProcessedVehicle extends MapVehicle {
   isOnline: boolean;
   location: string;
   latestData?: VehicleData;
@@ -496,7 +485,7 @@ export function Dashboard() {
   }, [processedVehicles]);
 
   // Event handlers
-  const handleVehicleClick = useCallback((vehicle: ProcessedVehicle) => {
+  const handleVehicleClick = useCallback((vehicle: MapVehicle) => {
     console.log('Dashboard: Vehicle selected from map:', vehicle.name);
     setSelectedVehicleId(vehicle.id);
   }, []);

--- a/components/GeofenceManager.tsx
+++ b/components/GeofenceManager.tsx
@@ -99,7 +99,8 @@ const MAP_ZOOM_LEVELS = {
 } as const;
 
 // 🔧 Enhanced utility functions
-const ensureArray = <T>(value: any): T[] => {
+// Avoid JSX ambiguity by using a trailing comma in the generic
+const ensureArray = <T,>(value: any): T[] => {
   if (Array.isArray(value)) return value;
   if (value?.data && Array.isArray(value.data)) return value.data;
   return [];

--- a/components/LiveTracking.tsx
+++ b/components/LiveTracking.tsx
@@ -195,7 +195,8 @@ const fetcher = async (url: string) => {
 };
 
 // Safe array utility
-const ensureArray = <T>(value: any): T[] => {
+// Include trailing comma to disambiguate from JSX
+const ensureArray = <T,>(value: any): T[] => {
   if (Array.isArray(value)) return value;
   if (value && typeof value === 'object' && value.data) {
     return Array.isArray(value.data) ? value.data : [];

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -29,7 +29,7 @@ interface ProjectGeofence {
 }
 
 // Simplified interfaces for map display
-interface ProcessedVehicle {
+export interface ProcessedVehicle {
   id: string;
   name: string;
   licensePlate: string;


### PR DESCRIPTION
## Summary
- avoid using cached data when it might be null
- reuse MapComponent's vehicle type in Dashboard
- fix type mismatch for map vehicle click handler
- disambiguate generic syntax in TSX utility helpers

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843511db77c8331b658fec16c05311d