### PR TITLE
Fix Mixed Content errors

### DIFF
--- a/api/file.ts
+++ b/api/file.ts
@@ -1,1 +1,4 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';
+// Use HTTPS by default to avoid Mixed Content errors when the site is served over HTTPS
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'https://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';


### PR DESCRIPTION
## Summary
- use HTTPS for the default API base URL to avoid Mixed Content when loading the dashboard

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6843e239434c8331b8056345854d220a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed the default API base URL to use HTTPS to prevent Mixed Content errors when loading the dashboard.

<!-- End of auto-generated description by cubic. -->

