### PR TITLE
Fix Mixed Content errors

### DIFF
--- a/api/file.ts
+++ b/api/file.ts
@@ -1,1 +1,7 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';
+// Base URL for the Directus backend
+// Use HTTP here because the EC2 server does not currently expose HTTPS.
+// The frontend should access this through Next.js API routes to avoid
+// mixed‑content issues.
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'http://ec2-13-229-83-7.ap-southeast-1.compute.amazonaws.com:8055';

--- a/components/CommandCenter.tsx
+++ b/components/CommandCenter.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { API_BASE_URL } from "../api/file";
+// Use internal API routes
 import { toast } from "sonner";
 import { 
   Command as CommandIcon, 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -97,7 +97,9 @@ interface DashboardStats {
 }
 
 // ===== CONSTANTS =====
-import { API_BASE_URL } from '../api/file';
+// Use internal API routes so the client never directly contacts the Directus
+// instance. This avoids mixed-content issues when the dashboard is served over
+// HTTPS.
 
 const REFRESH_INTERVALS = {
   VEHICLES: 30000,      // 30 seconds
@@ -227,7 +229,7 @@ const useUser = () => {
 
 const useVehicles = (userId?: string) => {
   const { data, error, isLoading, mutate } = useSWR(
-    userId ? `${API_BASE_URL}/items/vehicle?filter[user_id][_eq]=${userId}&limit=-1` : null,
+    userId ? `/api/vehicles?user_id=${userId}&limit=-1` : null,
     fetcher,
     {
       refreshInterval: REFRESH_INTERVALS.VEHICLES,
@@ -260,7 +262,7 @@ const useVehicleData = (vehicles: Vehicle[]) => {
   }, [vehicles]);
 
   const { data, error, isLoading, mutate } = useSWR(
-    gpsIds ? `${API_BASE_URL}/items/vehicle_datas?filter[gps_id][_in]=${gpsIds}&limit=1000&sort=-timestamp` : null,
+    userId && gpsIds ? `/api/vehicle-data?user_id=${userId}` : null,
     fetcher,
     {
       refreshInterval: REFRESH_INTERVALS.VEHICLE_DATA,
@@ -285,7 +287,7 @@ const useVehicleData = (vehicles: Vehicle[]) => {
 
 const useGeofences = (userId?: string) => {
   const { data, error, isLoading, mutate } = useSWR(
-    userId ? `${API_BASE_URL}/items/geofence?filter[user_id][_eq]=${userId}` : null,
+    userId ? `/api/geofences?user_id=${userId}` : null,
     fetcher,
     {
       refreshInterval: REFRESH_INTERVALS.GEOFENCES,

--- a/components/GeofenceManager.tsx
+++ b/components/GeofenceManager.tsx
@@ -85,9 +85,9 @@ interface UIState {
 }
 
 // 🔧 Constants with environment support
-import { API_BASE_URL } from '../api/file';
-const GEOFENCE_API_ENDPOINT = `${API_BASE_URL}/items/geofence`;
-const VEHICLE_API_ENDPOINT = `${API_BASE_URL}/items/vehicle`;
+// Use internal API routes so that requests go through the Next.js backend
+const GEOFENCE_API_ENDPOINT = '/api/geofences';
+const VEHICLE_API_ENDPOINT = '/api/vehicles';
 
 const DEFAULT_CENTER: [number, number] = [-2.5, 118.0];
 const SEARCH_DEBOUNCE_DELAY = 300;

--- a/components/HistoryManager.tsx
+++ b/components/HistoryManager.tsx
@@ -60,9 +60,9 @@ interface ProcessedVehicleForMap {
 }
 
 // API Configuration
-import { API_BASE_URL } from '../api/file';
-const VEHICLE_ENDPOINT = `${API_BASE_URL}/items/vehicle`;
-const VEHICLE_DATA_ENDPOINT = `${API_BASE_URL}/items/vehicle_datas`;
+// Use internal API routes to avoid cross origin requests
+const VEHICLE_ENDPOINT = '/api/vehicles';
+const VEHICLE_DATA_ENDPOINT = '/api/vehicle-data';
 
 // 🔧 Optimized SWR Configuration
 const swrConfig = {

--- a/components/LiveTracking.tsx
+++ b/components/LiveTracking.tsx
@@ -26,7 +26,7 @@ import {
 import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
 import useSWR from 'swr';
-import { API_BASE_URL } from '../api/file';
+// Requests should go through Next.js API routes
 
 const MapComponent = dynamic(() => import('./MapComponent').catch(() => ({ default: () => <div>Map not available</div> })), {
   ssr: false,
@@ -130,10 +130,10 @@ interface VehiclePositionHistory {
 }
 
 // API Configuration
-const GEOFENCE_API_BASE_URL = `${API_BASE_URL}/items/geofence`;
-const VEHICLE_API_ENDPOINT_BASE = `${API_BASE_URL}/items/vehicle`;
-const VEHICLE_DATA_API_ENDPOINT_BASE = `${API_BASE_URL}/items/vehicle_datas`;
-const ALERTS_API_ENDPOINT = `${API_BASE_URL}/items/alerts`; // NEW: Alert endpoint
+const GEOFENCE_API_BASE_URL = '/api/geofences';
+const VEHICLE_API_ENDPOINT_BASE = '/api/vehicles';
+const VEHICLE_DATA_API_ENDPOINT_BASE = '/api/vehicle-data';
+const ALERTS_API_ENDPOINT = '/api/alerts';
 
 // Optimized SWR configuration
 const swrConfig = {

--- a/pages/api/geofences.ts
+++ b/pages/api/geofences.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.log('Geofences API called with method:', req.method);
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { user_id } = req.query;
+    const { API_BASE_URL } = await import('../../api/file');
+
+    const params = new URLSearchParams();
+    if (user_id) {
+      params.set('filter[user_id][_eq]', String(user_id));
+    }
+    params.set('limit', '-1');
+    params.set('sort', '-date_created');
+
+    const url = `${API_BASE_URL}/items/geofence?${params.toString()}`;
+    console.log('Fetching geofences from:', url);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error('External geofences API error:', text);
+      throw new Error(`Failed to fetch geofences: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log('Geofences received:', data.data?.length || 0);
+
+    return res.status(200).json(data);
+  } catch (error: any) {
+    console.error('Geofences API error:', error);
+    return res.status(500).json({
+      error: 'Failed to fetch geofences',
+      message: error.message,
+    });
+  }
+}

--- a/pages/api/vehicles.ts
+++ b/pages/api/vehicles.ts
@@ -23,12 +23,12 @@ async function handleGetVehicles(req: NextApiRequest, res: NextApiResponse) {
     console.log('Fetching vehicles data for user_id:', user_id);
     
     const { API_BASE_URL } = await import('../../api/file');
-    let url = `${API_BASE_URL}/items/vehicle`;
-    
-    // Add filter if user_id is provided
+    const params = new URLSearchParams();
     if (user_id) {
-      url += `?filter[user_id][_eq]=${user_id}`;
+      params.set('filter[user_id][_eq]', String(user_id));
     }
+    params.set('limit', '-1');
+    const url = `${API_BASE_URL}/items/vehicle?${params.toString()}`;
     
     console.log('Fetching from URL:', url);
     


### PR DESCRIPTION
## Summary
- use HTTP backend URL internally and add a `/api/geofences` route
- route sidebar and dashboard data requests through Next.js API
- update geofence/vehicle/history managers and live tracking to call local API

## Testing
- `npm install`
- `npm run lint` *(fails: next not found and many TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_6843e239434c8331b8056345854d220a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed mixed content errors by routing all frontend data requests through Next.js API routes instead of calling the backend directly.

- **Bug Fixes**
  - Added a new `/api/geofences` route.
  - Updated geofence, vehicle, history, and live tracking components to use internal API routes.

<!-- End of auto-generated description by cubic. -->

